### PR TITLE
Allow a responseType to be specified for each command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ module.exports = new Slash.Command({
   name: 'echo',
   description: 'sends a message',
   permissions: ["SEND_MESSAGES"],
+  responseType: 4 // Type 4 responds with a message, showing the user's input (https://discord.com/developers/docs/interactions/slash-commands#interaction-response-interactionresponsetype)
   options: [{
     "name": "content",
     "description": "message the bot will send",
@@ -70,7 +71,7 @@ module.exports = new Slash.Command({
     // access the arguments passed
     const content = request.data.options.find(arg => arg.name === "content").value;
     // sends message containing the argument
-    interaction.sendMessage(content);
+    interaction.sendMessage(content, this);
   }
 })
 ```

--- a/README.md
+++ b/README.md
@@ -57,12 +57,12 @@ module.exports = new Slash.Command({
   name: 'echo',
   description: 'sends a message',
   permissions: ["SEND_MESSAGES"],
-  responseType: 4 // Type 4 responds with a message, showing the user's input (https://discord.com/developers/docs/interactions/slash-commands#interaction-response-interactionresponsetype)
+  responseType: 4, // Type 4 responds with a message, showing the user's input (https://discord.com/developers/docs/interactions/slash-commands#interaction-response-interactionresponsetype)
   options: [{
     "name": "content",
     "description": "message the bot will send",
     "type": 3 // Type 3 is string
-  }]
+  }],
   execute(interaction) {
     // access discord.Client() through interaction.client
     const client = interaction.client;

--- a/src/interaction.js
+++ b/src/interaction.js
@@ -2,13 +2,12 @@ class Interaction {
     constructor(client, request) {
       this.client = client;
       this.request = request;
-      this.responseType = 4;
     }
     
-    async sendMessage(content) {
+    async sendMessage(content, command) {
       const client = this.client;
       const request = this.request;
-      const type = this.responseType;
+      const type = command.responseType;
       client.api.interactions(request.id, request.token).callback.post({
         data: {
           type: type,
@@ -19,10 +18,10 @@ class Interaction {
       });
     }
   
-    async sendEphemeral(content) {
+    async sendEphemeral(content, command) {
       const client = this.client;
       const request = this.request;
-      const type = this.responseType;
+      const type = command.responseType;
       client.api.interactions(request.id, request.token).callback.post({
         data: {
           type: type,
@@ -34,10 +33,10 @@ class Interaction {
       });
     }
   
-    async sendEmbed(embed) {
+    async sendEmbed(embed, command) {
       const client = this.client;
       const request = this.request;
-      const type = this.responseType;
+      const type = command.responseType;
       client.api.interactions(request.id, request.token).callback.post({
         data: {
           type: type,

--- a/src/interaction.js
+++ b/src/interaction.js
@@ -7,7 +7,8 @@ class Interaction {
     async sendMessage(content, command) {
       const client = this.client;
       const request = this.request;
-      const type = command.responseType;
+      const type = command.responseType
+        || 4;
       client.api.interactions(request.id, request.token).callback.post({
         data: {
           type: type,
@@ -21,7 +22,8 @@ class Interaction {
     async sendEphemeral(content, command) {
       const client = this.client;
       const request = this.request;
-      const type = command.responseType;
+      const type = command.responseType
+        || 4;
       client.api.interactions(request.id, request.token).callback.post({
         data: {
           type: type,
@@ -36,7 +38,8 @@ class Interaction {
     async sendEmbed(embed, command) {
       const client = this.client;
       const request = this.request;
-      const type = command.responseType;
+      const type = command.responseType
+        || 4;
       client.api.interactions(request.id, request.token).callback.post({
         data: {
           type: type,


### PR DESCRIPTION
If this were to be merged, it would allow the bot dev to specify an [InteractionResponseType](https://discord.com/developers/docs/interactions/slash-commands#interaction-response-interactionresponsetype). If none is specified, default to type 4